### PR TITLE
Allow build on Haiku target

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -23,7 +23,11 @@ TARGET_NAME := pcsx1
 LIBM := -lm
 LIBZ := -lz
 LIBPTHREAD := -lpthread
+ifneq (,$(findstring Haiku,$(shell uname -s)))
+LIBDL := -ldlib
+else
 LIBDL := -ldl
+endif
 MMAP_WIN32=0
 EXTRA_LDFLAGS =
 

--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -1082,7 +1082,7 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
 	return ret;
 }
 
-static int uncompress2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
+static int uncompress_(void *out, unsigned long *out_size, void *in, unsigned long in_size)
 {
 	static z_stream z;
 	int ret = 0;
@@ -1161,7 +1161,7 @@ static int cdread_compressed(FILE *f, unsigned int base, void *dest, int sector)
 	if (is_compressed) {
 		cdbuffer_size_expect = sizeof(compr_img->buff_raw[0]) << compr_img->block_shift;
 		cdbuffer_size = cdbuffer_size_expect;
-		ret = uncompress2(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
+		ret = uncompress_(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
 		if (ret != 0) {
 			SysPrintf("uncompress failed with %d for block %d, sector %d\n",
 					ret, block, sector);

--- a/plugins/cdrcimg/cdrcimg.c
+++ b/plugins/cdrcimg/cdrcimg.c
@@ -98,7 +98,7 @@ static long CDRgetTD(unsigned char track, unsigned char *buffer)
 	return 0;
 }
 
-int uncompress2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
+int uncompress_(void *out, unsigned long *out_size, void *in, unsigned long in_size)
 {
 	static z_stream z;
 	int ret = 0;
@@ -199,7 +199,7 @@ static long CDRreadTrack(unsigned char *time)
 		ret = uncompress(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
 		break;
 	case CDRC_ZLIB2:
-		ret = uncompress2(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
+		ret = uncompress_(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
 		break;
 	case CDRC_BZ:
 		ret = pBZ2_bzBuffToBuffDecompress((char *)cdbuffer->raw, (unsigned int *)&cdbuffer_size,


### PR DESCRIPTION
- uncompress2 already exists in zlib on Haiku, renamed for unicity
- fixed Makefile for Haiku